### PR TITLE
Handle the case when wavve return without any parameter

### DIFF
--- a/source_wavve.py
+++ b/source_wavve.py
@@ -71,7 +71,7 @@ class SourceWavve(SourceBase):
         new_lines = []
         for line in data.splitlines():
             line = line.strip()
-            if line.startswith != "#" and ".ts?" in line:
+            if line.startswith != "#" and ".ts" in line:
                 line = f"{prefix}/{line}"
             new_lines.append(line)
         new_lines = "\n".join(new_lines)


### PR DESCRIPTION
normally wavve return M3U format with parameters but sometimes returns without any parameter, returns list of *.ts files only

This patch migrated from https://github.com/by275/klive/pull/1